### PR TITLE
Add library that generate doc with installed graphviz version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <slf4j-api-version>2.0.5</slf4j-api-version>
         <jakarta-version>6.0.0</jakarta-version>
         <native-maven-plugin-version>0.9.19</native-maven-plugin-version>
+        <commons-exec-version>1.3</commons-exec-version>
 
         <!-- Versions of plugins -->
         <junit-version>5.9.2</junit-version>
@@ -231,6 +232,11 @@
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
             <version>${native-maven-plugin-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+            <version>${commons-exec-version}</version>
         </dependency>
 
         <!-- Third party dependencies for testing -->


### PR DESCRIPTION
This issue arises because the Spring Framework and GraalVM are incompatible with building a JavaScript engine into the native image. As a result, in order to generate documentation, Graphviz must be explicitly installed on the operating system.

Fix issue on AME regarding https://github.com/eclipse-esmf/esmf-sdk/issues/323