### PR TITLE
Remove -DskipTests from native image build steps

### DIFF
--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -81,13 +81,13 @@ jobs:
 
       - name: Creating native image (Mac)
         if: matrix.os == 'macos-13'
-        run: mvn install -P native-image,native-test-config -DskipTests -Dos.platform=mac -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
+        run: mvn install -P native-image,native-test-config -Dos.platform=mac -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Creating native image (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: mvn install -P native-image,native-test-config -DskipTests -Dos.platform=linux -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
+        run: mvn install -P native-image,native-test-config -Dos.platform=linux -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
 
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Creating native image (Win)
         if: matrix.os == 'windows-latest'
-        run: mvn install -P native-image,native-test-config -DskipTests -D os.platform=win -D maven.wagon.httpconnectionManager.ttlSeconds=60
+        run: mvn install -P native-image,native-test-config -D os.platform=win -D maven.wagon.httpconnectionManager.ttlSeconds=60
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The -DskipTests flag was removed from the Maven commands for creating native images in the GitHub Actions workflow. This ensures that tests are not skipped during the build process for Mac, Linux, and Windows.

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes #(number of issue in GitHub)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
